### PR TITLE
fix(bridge/esx/client): Fix removing status

### DIFF
--- a/bridge/esx/client.lua
+++ b/bridge/esx/client.lua
@@ -32,7 +32,7 @@ RegisterNetEvent("pickle_consumables:executeStatus", function(status, value)
     if value >= 0 then
         TriggerEvent('esx_status:add', status, value)
     else
-        TriggerEvent('esx_status:remove', status, value)
+        TriggerEvent('esx_status:remove', status, -value)
     end
 end)
 


### PR DESCRIPTION
esx_status only works with positive numbers for removing status, with this change this converts the amount to a positive number so that it will work properly.

